### PR TITLE
Enable source maps

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -44,7 +44,12 @@ module.exports = {
                 test: /\.scss$/,
                 use: [
                     MiniCssExtractPlugin.loader,
-                    'css-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: true
+                        }
+                    },
                     {
                         loader: 'postcss-loader',
                         options: {
@@ -58,7 +63,12 @@ module.exports = {
                             ],
                         }
                     },
-                    'sass-loader',
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: true
+                        }
+                    },
                 ]
             },
             {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -112,7 +112,7 @@ module.exports = {
         ]
     },
     plugins: [
-        new CleanWebpackPlugin(['Dist'], {
+        new CleanWebpackPlugin(['Public'], {
             verbose: false,
         }),
         new WebpackBar({


### PR DESCRIPTION
Added sourcemap option to css-loader and sass-loader. Source maps resolve to .scss partials again.

Removed leftover 'Dist' path in cleanwebpackplugin and replaced it with the new 'Public' path