### PR TITLE
[TASK] Always copy static images from Images/Misc to Public

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -132,9 +132,10 @@ module.exports = {
         new UglifyJsPlugin({
             extractComments: true
         }),
-        new CopyPlugin([
-            {from: 'Assets/Images/Misc', to: 'Images/Misc'}
-        ]),
+        new CopyPlugin(
+            [{from: 'Assets/Images/Misc', to: 'Images/Misc'}],
+            {copyUnmodified: true}),
+        ),
         new CopyPlugin([
             {from: 'Assets/JavaScripts/static', to: 'JavaScripts'}
         ]),


### PR DESCRIPTION
Static Image Assets only get copied when executing npm task webpack:dev:build and not when executing webpack:dev:build:watch, because the watcher does not look for changes in image file types. This solution always copies the Assest/Images/Misc Folder.